### PR TITLE
Grouping mypy packages at Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
           "boto3",
           "botocore"
         ]
+      },
+      {
+        "groupName": "mypy packages",
+        "packageNames": [
+          "mypy",
+          "typed-ast"
+        ]
       }
     ]
   }


### PR DESCRIPTION
typed-ast is depended by mypy.
So it should be updated in same time.