### PR TITLE
Add dummy AWS access tokens foc Circle CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
           command: |
             . venv/bin/activate
             flake8 bamboo_crawler tests
-            export AWS_ACCESS_KEY_ID=''
-            export AWS_SECRET_ACCESS_KEY=''
+            export AWS_ACCESS_KEY_ID='1234'
+            export AWS_SECRET_ACCESS_KEY='5678'
             python setup.py test
 
       - store_artifacts:


### PR DESCRIPTION
Because some version of botocore requires non-empty tokens.